### PR TITLE
Allow host communication

### DIFF
--- a/lib/proxy/vm.rs
+++ b/lib/proxy/vm.rs
@@ -68,6 +68,11 @@ impl Proxy {
             }
         }
 
+        // Allow communication with host
+        if ipv4_pkt.dst_addr() == self.host.gateway_ip {
+            return Some(());
+        }
+
         if ipv4_pkt.protocol() == IpProtocol::Udp {
             let udp_pkt = UdpPacket::new_checked(ipv4_pkt.payload()).ok()?;
 
@@ -77,11 +82,8 @@ impl Proxy {
                 return Some(());
             }
 
-            // Allow DHCP communication with the bootpd(8) on host
-            let allowed_dhcp_target =
-                ipv4_pkt.dst_addr().is_broadcast() || ipv4_pkt.dst_addr() == self.host.gateway_ip;
-
-            if udp_pkt.is_dhcp_request() && allowed_dhcp_target {
+            // Allow DHCP communication with the bootpd(8) on host via broadcast address
+            if udp_pkt.is_dhcp_request() && ipv4_pkt.dst_addr().is_broadcast() {
                 return Some(());
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ fn try_main() -> Result<(), Box<dyn std::error::Error>> {
                 .exec();
         }
 
-        return Err("root privileges are required to run".into());
+        return Err("root privileges are required to run and passwordless sudo was not available".into());
     }
 
     // Set bootpd(8) min/max lease time while still having the root privileges


### PR DESCRIPTION
Initially, this way of communication was prohibited to avoid exposing sensitive services on host's `127.0.0.1` to the VM. However, it seems to be limiting as we can't even SSH to the VM from host.

While implementing a [stateful packet filtering](https://en.wikipedia.org/wiki/Stateful_firewall) is an option, it's quite complicated and requires us to [account for TCP connection lifetimes](https://www.usenix.org/legacy/events/sec01/invitedtalks/rooij.pdf) and connection-less protocols like UDP.

However, the VM is actually always communicates with the host via the bridge interface, which has a separate IP (also called gateway IP in the code).

Based on that, the VM won't be able to communicate with host's `127.0.0.1` directly, and for those services that are exposed on `*:PORT`, these services should assume that in their threat model already as the attacker might be able to reach them from LAN/WAN.

For example, here are the services running on `*:PORT` on my macOS Monterey:

```
% sudo lsof -i -P | grep LISTEN | grep :$PORT
rapportd    554            edi    3u  IPv4 0x7e4f0114f9d2c295      0t0    TCP *:49330 (LISTEN)
rapportd    554            edi    4u  IPv6 0x7e4f0119c0cf5a7d      0t0    TCP *:49330 (LISTEN)
webstorm   2129            edi   23u  IPv6 0x7e4f0119c0cf287d      0t0    TCP localhost:6944 (LISTEN)
webstorm   2129            edi   29u  IPv6 0x7e4f0119c46a367d      0t0    TCP localhost:63344 (LISTEN)
idea      69421            edi   11u  IPv6 0x7e4f0119c0ceda7d      0t0    TCP localhost:6942 (LISTEN)
idea      69421            edi   44u  IPv6 0x7e4f0119c469617d      0t0    TCP localhost:63342 (LISTEN)
com.docke 89236            edi   30u  IPv4 0x7e4f0114f92f8d2d      0t0    TCP *:63695 (LISTEN)
vpnkit-br 89293            edi    8u  IPv4 0x7e4f0114f92f8d2d      0t0    TCP *:63695 (LISTEN)
```

While the `rapportd` daemon provides "Phone Call Handoff and other communication features between Apple devices" and is probably meant to be reachable from Wi-Fi, the Docker-related daemon listening on `*:63695` seems to be the one sending the actual Docker API commands, not receiving them (through it's still looks sketchy for the Docker Desktop to expose things like that). The IntelliJ should be safe as it's listening on `127.0.0.1`.

Resolves #6.