### PR TITLE
Increase the default bootpd(8) lease time from 1 to 10 minutes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ struct Args {
     #[clap(
         long,
         help = "set bootpd(8) lease time to this value (in seconds) before starting the VM",
-        default_value_t = 60
+        default_value_t = 600
     )]
     bootpd_lease_time: u32,
 


### PR DESCRIPTION
This should be still a small enough lease time, assuming that a single host can run only two Tart VMs at a time.

If I've calculated this right, a single host with a /24 subnet (254 addresses) will exhaust its DHCP pool if a new VM will be spawned more frequently than each `600 / 254 = ~2.4` seconds.

Might help with the https://github.com/cirruslabs/cirrus-cli/issues/573.