### PR TITLE
Don't panic in Drop

### DIFF
--- a/lib/host.rs
+++ b/lib/host.rs
@@ -107,7 +107,7 @@ impl Host {
             .map_err(|err| Error::VmnetFailed { source: err })?;
 
         // Now let the callback finish
-        self.callback_can_continue_tx.send(()).unwrap();
+        let _ = self.callback_can_continue_tx.send(());
 
         self.interface
             .finalize()


### PR DESCRIPTION
Currently when the Softnet panics, it still tries to `Drop` the objects. However, the current implementation of `Host`'s `Drop` also panics, which can override the original error.

Since `mpsc::SendError` is [only thrown when attempting to send via a closed channel](https://doc.rust-lang.org/std/sync/mpsc/struct.SendError.html), we can simply ignore this error altogether for simplicity's sake because we'll either succeed in sending the message, or fail, which means we've already panicked and there is a more important error to show to the user.

Resolves https://github.com/cirruslabs/softnet/issues/11.