### PR TITLE
Enable full backtrace

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -49,7 +49,7 @@ struct Args {
 fn main() -> ExitCode {
     // Enable backtraces by default
     if env::var("RUST_BACKTRACE").is_err() {
-        env::set_var("RUST_BACKTRACE", "1");
+        env::set_var("RUST_BACKTRACE", "full");
     }
 
     // Initialize Sentry


### PR DESCRIPTION
To include line numbers. Right now errors doesn't contain them:

```text
Connection reset by peer (os error 54)

Thread 0
0   softnet                         0x100633cb0         softnet::proxy::Proxy::run
1   softnet                         0x1003f0d0c         softnet::main
2   std                             0x1003f13f4         std::sys_common::backtrace::__rust_begin_short_backtrace
3   std                             0x1003f140c         std::rt::lang_start::{{closure}}
4   std                             0x1006c2fc4         std::rt::lang_start_internal
5   <unknown>                       0x1003f13b8         _main
```