### PR TITLE
Upload symbols and sources to Sentry

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,6 +27,8 @@ task:
     - brew install go goreleaser/tap/goreleaser-pro
   build_script:
     - cargo build --profile release-with-debug
+  install_sentry_cli_script:
+    - brew install getsentry/tools/sentry-cli
   upload_sentry_debug_files_script:
     - cd target/release-with-debug/
     # Generate and upload symbols

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -18,10 +18,20 @@ task:
   env:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
     GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
+    SENTRY_ORG: cirrus-labs
+    SENTRY_PROJECT: persistent-workers
   install_rust_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   install_goreleaser_script:
     - brew install go goreleaser/tap/goreleaser-pro
   build_script:
     - cargo build --profile release-with-debug
+  upload_sentry_debug_files_script:
+    - cd target/release-with-debug/
+    # Generate and upload symbols
+    - dsymutil softnet
+    - sentry-cli debug-files upload -o $SENTRY_ORG -p $SENTRY_PROJECT softnet.dSYM/
+    # Bundle and upload sources
+    - sentry-cli debug-files bundle-sources softnet.dSYM/
+    - sentry-cli debug-files upload -o $SENTRY_ORG -p $SENTRY_PROJECT softnet.src.zip
   release_script: goreleaser

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,6 +20,7 @@ task:
     GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
     SENTRY_ORG: cirrus-labs
     SENTRY_PROJECT: persistent-workers
+    SENTRY_AUTH_TOKEN: ENCRYPTED[!c16a5cf7da5f856b4bc2f21fe8cb7aa2a6c981f851c094ed4d3025fd02ea59a58a86cee8b193a69a1fc20fa217e56ac3!]
   install_rust_script:
     - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
   install_goreleaser_script:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "findshlibs"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40b9e59cd0f7e0806cca4be089683ecb6434e602038df21fe6bf6711b2f07f64"
+dependencies = [
+ "cc",
+ "lazy_static",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1103,7 @@ dependencies = [
  "sentry-backtrace",
  "sentry-contexts",
  "sentry-core",
+ "sentry-debug-images",
  "sentry-panic",
  "tokio",
  "ureq",
@@ -1144,6 +1157,17 @@ dependencies = [
  "sentry-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "sentry-debug-images"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3995208135571444b7d5a247f42bd36677553bb64185d85b317acdc1789749b3"
+dependencies = [
+ "findshlibs",
+ "once_cell",
+ "sentry-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,5 +25,5 @@ ip_network = "0.4.1"
 users = "0.11.0"
 system-configuration = "0.5.0"
 num_enum = "0.5.7"
-sentry = "0.29.1"
+sentry = { version = "0.29.1", features = ["debug-images"] }
 sentry-anyhow = { version = "0.29.1", features = ["backtrace"] }


### PR DESCRIPTION
Resolves the issue faced in https://github.com/cirruslabs/softnet/pull/14.

This also needs a `SENTRY_AUTH_TOKEN` variable to be set in `.cirrus.yml`.