### PR TITLE
Switch back to nightly toolchain

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
To get proper error chains in Sentry, and thus proper grouping, and avoid this:

<img width="914" alt="Screenshot 2022-12-14 at 23 02 53" src="https://user-images.githubusercontent.com/85709/207688881-1f79fc3f-b6d3-45ca-8f0b-2021e85c1396.png">
