### PR TITLE
Allow softnet to access the AWS Metadata service

### DIFF
--- a/lib/proxy/vm.rs
+++ b/lib/proxy/vm.rs
@@ -64,7 +64,9 @@ impl Proxy {
             let dst_is_global =
                 ip_network::IpNetwork::from(Ipv4Addr::from(ipv4_pkt.dst_addr().0)).is_global();
 
-            if lease.valid_ip_source(ipv4_pkt.src_addr()) && dst_is_global {
+            if (lease.valid_ip_source(ipv4_pkt.src_addr()) && dst_is_global)
+                || ipv4_pkt.dst_addr() == Ipv4Addr::new(169, 254, 169, 254).into()
+            {
                 return Some(());
             }
         }


### PR DESCRIPTION
## Objective

To allow Tart VM's to use AWS credentials when running VM's on AWS EC2.

Currently softnet blocks all [non global](https://github.com/cirruslabs/softnet/blob/d635751948f92529db0702d73f2a3e9763fea55e/lib/proxy/vm.rs#L67) traffic from the VM. AWS Metadata service is on `169.254.169.254`, but it cannot be accessed from the VM, since it is not global traffic

The Metadata service will allow us to use `awscli` inside the VM and use the IAM credentials from the host EC2. 

### Note

I have never touched rust and was not sure how to test softnet locally, feel free to modify the code.