### PR TITLE
Added a way to enable host-only networking through tart using --net-host

### DIFF
--- a/lib/host.rs
+++ b/lib/host.rs
@@ -18,10 +18,13 @@ pub struct Host {
 }
 
 impl Host {
-    pub fn new() -> Result<Host> {
-        // Initialize a vmnet.framework NAT interface with isolation enabled
+    pub fn new(vm_net_type: &str) -> Result<Host> {
+        // Initialize a vmnet.framework NAT or Host interface with isolation enabled
         let mut interface = vmnet::Interface::new(
-            Mode::Shared(Default::default()),
+            match vm_net_type {
+                "host" => Mode::Host(Default::default()),
+                /* nat */_ => Mode::Shared(Default::default()),
+            },
             Options {
                 enable_isolation: Some(true),
                 ..Default::default()

--- a/lib/mod.rs
+++ b/lib/mod.rs
@@ -1,5 +1,6 @@
 mod dhcp_snooper;
-pub mod host;
+mod host;
+pub use host::NetType;
 mod poller;
 pub mod proxy;
 mod vm;

--- a/lib/mod.rs
+++ b/lib/mod.rs
@@ -1,5 +1,5 @@
 mod dhcp_snooper;
-mod host;
+pub mod host;
 mod poller;
 pub mod proxy;
 mod vm;

--- a/lib/proxy/mod.rs
+++ b/lib/proxy/mod.rs
@@ -4,6 +4,7 @@ mod vm;
 
 use crate::dhcp_snooper::DhcpSnooper;
 use crate::host::Host;
+use crate::host::NetType;
 use crate::poller::Poller;
 use crate::vm::VM;
 use anyhow::Result;
@@ -22,7 +23,7 @@ pub struct Proxy {
 }
 
 impl Proxy {
-    pub fn new(vm_fd: RawFd, vm_mac_address: MacAddress, vm_net_type: &str) -> Result<Proxy> {
+    pub fn new(vm_fd: RawFd, vm_mac_address: MacAddress, vm_net_type: NetType) -> Result<Proxy> {
         let vm = VM::new(vm_fd)?;
         let host = Host::new(vm_net_type)?;
         let poller = Poller::new(vm.as_raw_fd(), host.as_raw_fd())?;

--- a/lib/proxy/mod.rs
+++ b/lib/proxy/mod.rs
@@ -22,9 +22,9 @@ pub struct Proxy {
 }
 
 impl Proxy {
-    pub fn new(vm_fd: RawFd, vm_mac_address: MacAddress) -> Result<Proxy> {
+    pub fn new(vm_fd: RawFd, vm_mac_address: MacAddress, vm_net_type: &str) -> Result<Proxy> {
         let vm = VM::new(vm_fd)?;
-        let host = Host::new()?;
+        let host = Host::new(vm_net_type)?;
         let poller = Poller::new(vm.as_raw_fd(), host.as_raw_fd())?;
 
         Ok(Proxy {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use nix::sys::signal::{signal, SigHandler, Signal};
 use privdrop::PrivDrop;
+use softnet::host::NetType;
 use softnet::proxy::Proxy;
 use std::borrow::Cow;
 use std::env;
@@ -28,8 +29,8 @@ struct Args {
     #[clap(long, help = "MAC address to enforce for the VM")]
     vm_mac_address: mac_address::MacAddress,
 
-    #[clap(long, help = "type of network to use for the VM: 'nat', 'host' (default: nat)")]
-    vm_net_type: Option<String>,
+    #[clap(long, arg_enum, help = "type of network to use for the VM: 'nat', 'host' (default: nat)")]
+    vm_net_type: NetType,
 
     #[clap(
         long,
@@ -105,14 +106,6 @@ fn try_main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Enable setting of the vm_net_type through the env variable
-    let mut vm_net_type = args.vm_net_type.unwrap_or(String::new());
-    if vm_net_type.is_empty() {
-        if let Ok(val) = env::var("SOFTNET_NET_TYPE") {
-            vm_net_type = val;
-        }
-    }
-
     // Retrieve real (not effective) user and group names
     let current_user_name = get_current_username()
         .ok_or(anyhow!("failed to resolve real user name"))?
@@ -151,7 +144,7 @@ fn try_main() -> anyhow::Result<()> {
     set_bootpd_lease_time(args.bootpd_lease_time);
 
     // Initialize the proxy while still having the root privileges
-    let mut proxy = Proxy::new(args.vm_fd as RawFd, args.vm_mac_address, vm_net_type.as_str())
+    let mut proxy = Proxy::new(args.vm_fd as RawFd, args.vm_mac_address, args.vm_net_type)
         .context("failed to initialize proxy")?;
 
     // Drop effective privileges to the user

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context};
 use clap::Parser;
 use nix::sys::signal::{signal, SigHandler, Signal};
 use privdrop::PrivDrop;
-use softnet::host::NetType;
+use softnet::NetType;
 use softnet::proxy::Proxy;
 use std::borrow::Cow;
 use std::env;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ struct Args {
     #[clap(long, help = "MAC address to enforce for the VM")]
     vm_mac_address: mac_address::MacAddress,
 
-    #[clap(long, arg_enum, help = "type of network to use for the VM: 'nat', 'host' (default: nat)")]
+    #[clap(long, arg_enum, help = "type of network to use for the VM", default_value_t=NetType::Nat)]
     vm_net_type: NetType,
 
     #[clap(


### PR DESCRIPTION
This change adds an option `--vm-net-type` which allows to run VM in isolated host-only subnet from tart like that:
```
$ tart run --net-softnet --net-host test_vm 
```

Without specifying `--vm-net-type` or with `=nat` the softnet will bind to regular shared subnet and allow the regular behavior.

Later this functionality could be enabled in tart to choose the right net type for the particular VM during run.

Reason: building strict images requires a complete control over the networking (to make sure there are no mothership connection or accidental unwanted updates received during the build process).

Note: this is my first change for Rust logic, so could be not well optimized or structured - so any suggestion on how to make it better is very welcome!

fixes: #31 