### PR TITLE
PartialEq for ExposedPort

### DIFF
--- a/lib/proxy/exposed_port.rs
+++ b/lib/proxy/exposed_port.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context, Error};
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ExposedPort {
     pub external_port: u16,
     pub internal_port: u16,


### PR DESCRIPTION
## What

This PR adds `PartialEq` missing for `ExposedPort` which previously resulted in compilation error.

## Reproducing

### Environment

The issue is reproduced on macOS using fresh `nightly` (2025-03-01).

<details><summary>Click here for details</summary>

```sh
❯ sw_vers
ProductName:		macOS
ProductVersion:		15.3.1
BuildVersion:		24D70

❯ curl https://github.com/nix-community/fenix/blob/f44d7c3596ff028ad9f7fcc31d1941ed585f11b3/data/nightly.json |  jq '."aarch64-apple-darwin".minimal'
{
  "date": "2025-03-01",
  "components": {
    "rustc": {
      "url": "https://static.rust-lang.org/dist/2025-03-01/rustc-nightly-aarch64-apple-darwin.tar.gz",
      "sha256": "041e052b63c4a83094e1ef755f9bf07229c74efc28e163ae6b376bc776b920e8"
    },
    "cargo": {
      "url": "https://static.rust-lang.org/dist/2025-03-01/cargo-nightly-aarch64-apple-darwin.tar.gz",
      "sha256": "0ef934cf4f321abcb684f6acf9baafcba6eb148e27848958b1b68f9745d6fa6c"
    },
    "rust-std": {
      "url": "https://static.rust-lang.org/dist/2025-03-01/rust-std-nightly-aarch64-apple-darwin.tar.gz",
      "sha256": "72eaeb59df2147fdf857095e4c0082a7f8d6ec0adb8b2b91464ab41254ac7c47"
    }
  }
}
```

</details>

### Building

For better reproducibility, I hacked a small [nix flake](https://github.com/ink-splatters/softnet-flake) which among other things, sets custom `RUSTFLAGS` used when the issue was found.

### Broken build (actual reproducing): [0.13.1-upstream](https://github.com/ink-splatters/softnet-flake/releases/tag/0.13.1-upstream)
<details><summary>Click here for error details</summary>

```
❯ nix --experimental-features 'nix-command flakes' --accept-flake-config build github:ink-splatters/softnet-flake/0.13.1-upstream
...

       last 25 log lines:
       > 41 | |                 external_port: 2222,
       > 42 | |                 internal_port: 22
       > 43 | |             },
       > 44 | |             "2222:22".parse().unwrap()
       > 45 | |         );
       >    | |         ^
       >    | |         |
       >    | |_________ExposedPort
       >    |           _
       >    |
       > note: an implementation of `PartialEq<_>` might be missing for `ExposedPort`
       >   --> lib/proxy/exposed_port.rs:5:1
       >    |
       > 5  | pub struct ExposedPort {
       >    | ^^^^^^^^^^^^^^^^^^^^^^ must implement `PartialEq<_>`
       >    = note: this error originates in the macro `assert_eq` (in Nightly builds, run with -Z macro-backtrace for more info)
       > help: consider annotating `ExposedPort` with `#[derive(PartialEq)]`
```

</details>

### Building the commit of this PR

[0.13.1+20250305](https://github.com/ink-splatters/softnet-flake/releases/tag/0.13.1) 
