### PR TITLE
Avoid using one-shot triggered events

### DIFF
--- a/lib/proxy/mod.rs
+++ b/lib/proxy/mod.rs
@@ -81,7 +81,7 @@ impl Proxy<'_> {
                     .tick(&mut self.host, self.dhcp_snooper.lease());
             }
 
-            self.poller.rearm()?;
+            self.poller.rearm();
         }
     }
 


### PR DESCRIPTION
This avoids calling `kevent(2)` needlessly on each `rearm()` by not using one-shot triggered events.