### PR TITLE
Build universal binary instead of architecture dependent

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,38 +2,32 @@ env:
   PATH: "$PATH:$HOME/.cargo/bin"
 
 task:
-  name: Build
+  name: Release (Dry Run)
+  only_if: $CIRRUS_TAG == ''
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
-  install_rust_script:
-    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - rustup toolchain install nightly-aarch64-apple-darwin
-    - rustup target add x86_64-apple-darwin
-  build_script:
-    - cargo build --target aarch64-apple-darwin --target x86_64-apple-darwin
+    image: ghcr.io/cirruslabs/macos-sequoia-xcode:latest
+  install_rust_script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  install_script: brew install go goreleaser/tap/goreleaser-pro
+  build_script: goreleaser build --snapshot
+  goreleaser_artifacts:
+    path: "dist/**"
 
 task:
   name: Release
   only_if: $CIRRUS_TAG != ''
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-sonoma-xcode:latest
+    image: ghcr.io/cirruslabs/macos-sequoia-xcode:latest
   env:
     GITHUB_TOKEN: ENCRYPTED[!98ace8259c6024da912c14d5a3c5c6aac186890a8d4819fad78f3e0c41a4e0cd3a2537dd6e91493952fb056fa434be7c!]
     GORELEASER_KEY: ENCRYPTED[!9b80b6ef684ceaf40edd4c7af93014ee156c8aba7e6e5795f41c482729887b5c31f36b651491d790f1f668670888d9fd!]
     SENTRY_ORG: cirrus-labs
     SENTRY_PROJECT: persistent-workers
     SENTRY_AUTH_TOKEN: ENCRYPTED[!c16a5cf7da5f856b4bc2f21fe8cb7aa2a6c981f851c094ed4d3025fd02ea59a58a86cee8b193a69a1fc20fa217e56ac3!]
-  install_rust_script:
-    - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    - rustup toolchain install nightly-aarch64-apple-darwin
-    - rustup target add x86_64-apple-darwin
-  install_script:
-    - brew install go goreleaser/tap/goreleaser-pro getsentry/tools/sentry-cli
-  build_script:
-    - cargo build --target aarch64-apple-darwin --target x86_64-apple-darwin --profile release-with-debug
+  install_rust_script: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  install_script: brew install go goreleaser/tap/goreleaser-pro getsentry/tools/sentry-cli
   release_script: goreleaser
   upload_sentry_debug_files_script:
-    - cd target/aarch64-apple-darwin/release-with-debug/
+    - cd target/aarch64-apple-darwin/release/
     # Generate and upload symbols
     - dsymutil softnet
     - sentry-cli debug-files upload -o $SENTRY_ORG -p $SENTRY_PROJECT softnet.dSYM/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,26 +1,27 @@
+---
+version: 2
 project_name: softnet
 
 builds:
-  - id: softnet
-    builder: prebuilt
-    goamd64: [v1]
-    goos:
-      - darwin
-    goarch:
-      - arm64
-      - amd64
-    prebuilt:
-      path: 'target/{{- if eq .Arch "arm64" }}aarch64{{- else }}x86_64{{ end }}-apple-darwin/release-with-debug/softnet'
+  - builder: rust
+    command: build
+    targets:
+      - aarch64-apple-darwin
+      - x86_64-apple-darwin
+
+universal_binaries:
+  - replace: true
 
 archives:
-  - id: regular
-    name_template: "{{ .ProjectName }}-{{ .Arch }}"
+  - name_template: "{{ .ProjectName }}"
+    formats:
+      - tar.gz
 
 release:
   prerelease: auto
 
 brews:
-  - name: softnet
+  - name: "{{ .ProjectName }}"
     repository:
       owner: cirruslabs
       name: homebrew-cli

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,6 @@ prefix-trie = "0"
 ipnet = "2"
 oslog = "0.2.0"
 log = "0.4.27"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
Also tweaked some things:

- Updated CI image to latest (macOS Sequoia).
- Changed first CI stage to "Release (Dry Run)" same as in [cirruslabs/tart](https://github.com/cirruslabs/tart).
- Make a release artifact as tar.gz instead of regular binary.

Similar pull request: https://github.com/cirruslabs/tart/pull/995