### PR TITLE
fix(homebrew): wrap macOS version dependency in on_macos block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,4 +30,6 @@ brews:
     description: Software networking with isolation for Tart
     skip_upload: auto
     custom_block: |
-      depends_on :macos => :sequoia
+      on_macos do
+        depends_on :macos => :sequoia
+      end


### PR DESCRIPTION
GoReleaser's Homebrew template always emits a bare `depends_on :macos` for macOS-only formulae. Combining that with the `depends_on :macos => :sequoia` line injected via custom_block triggers a Homebrew deprecation warning on `brew upgrade`:

```
  Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.
  Please report this issue to the cirruslabs/homebrew-cli tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
    /opt/homebrew/Library/Taps/cirruslabs/homebrew-cli/softnet.rb:18
```

Declaring the version constraint inside an `on_macos` block is the form Homebrew recommends and silences the warning without changing behavior (still macOS-only, Sequoia or newer).

Upstream issue:

- https://github.com/cirruslabs/homebrew-cli/issues/14

Related PR for `tart` formula, which I also use:

- https://github.com/openai/tart/pull/1264