### PR TITLE
goreleaser: nest versioned depends_on macos in on_macos block

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,4 +30,6 @@ brews:
     description: Software networking with isolation for Tart
     skip_upload: auto
     custom_block: |
-      depends_on :macos => :sequoia
+      on_macos do
+        depends_on macos: :sequoia
+      end


### PR DESCRIPTION
The generated Homebrew formula emits a deprecation warning on every brew command:

    Warning: Calling `depends_on :macos` with `depends_on macos:` is
    deprecated! Use `depends_on :macos` with `depends_on macos:` inside
    an `on_macos` block instead.
      cirruslabs/homebrew-cli/softnet.rb:18

This wraps the versioned `depends_on :macos => :sequoia` in the goreleaser
`custom_block` in an `on_macos` block as Homebrew now requires, so future
releases regenerate the formula without the warning. No behavior change.

Companion PR fixing the currently published formula: cirruslabs/homebrew-cli#15