### PR TITLE
goreleaser: emit non-deprecated depends_on macos: form

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,4 +30,6 @@ brews:
     description: Software networking with isolation for Tart
     skip_upload: auto
     custom_block: |
-      depends_on :macos => :sequoia
+      on_macos do
+        depends_on macos: :sequoia
+      end


### PR DESCRIPTION
## Summary

The Homebrew formula generated by this project's GoReleaser config (`.goreleaser.yml` → `brews` → `custom_block`) emits a deprecation warning on every `brew` invocation against `cirruslabs/homebrew-cli`:

```
Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.
Please report this issue to the cirruslabs/homebrew-cli tap (not Homebrew/* repositories), or even better, submit a PR to fix it:
  /opt/homebrew/Library/Taps/cirruslabs/homebrew-cli/softnet.rb:18
```

The cause is the legacy hash-rocket form `depends_on :macos => :sequoia` that this config injects into the generated `softnet.rb`. The brew formula header notes `# This file was generated by GoReleaser. DO NOT EDIT.`, so the only correct fix lives here, not in the tap.

## Change

Replaces the legacy form with the modern `on_macos do ... end` block, which is what Homebrew's deprecation message suggests:

```yaml
custom_block: |
  on_macos do
    depends_on macos: :sequoia
  end
```

This is semantically equivalent (softnet is already a macOS-only project per its build targets) and produces a generated formula that no longer warns.

## Notes

- The `brews.repository` field still points to `cirruslabs/homebrew-cli` from the pre-transfer days. That's left untouched by this PR \u2014 separate concern from the deprecation.
- I have a corresponding local edit applied on my machine to confirm the fix silences the warning end-to-end; once this is released the generated tap formula will pick it up automatically.