### PR TITLE
Fix deprecated `depends_on macos:` syntax in generated Homebrew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,4 +30,6 @@ brews:
     description: Software networking with isolation for Tart
     skip_upload: auto
     custom_block: |
-      depends_on :macos => :sequoia
+      on_macos do
+        depends_on macos: :sequoia
+      end


### PR DESCRIPTION
The generated `softnet.rb` formula triggers a Homebrew deprecation warning on every evaluation (e.g. during `brew update`/`upgrade`):

> Warning: Calling `depends_on :macos` with `depends_on macos:` is deprecated! Use `depends_on :macos` with `depends_on macos:` inside an `on_macos` block instead.

**Cause:** GoReleaser auto-emits a bare `depends_on :macos` for the darwin-only build targets, and `brews.custom_block` adds a top-level versioned `depends_on :macos => :sequoia`. Homebrew (`software_spec.rb`) now deprecates having both a bare and a versioned macOS dependency at the top level.

**Fix:** wrap the version constraint in an `on_macos` block — the form Homebrew's own deprecation message recommends — and use the blessed `depends_on macos: :sequoia` keyword. (The `=> :sequoia` hash-rocket and the `">= :sequoia"` string forms are both independently deprecated.) Semantics are unchanged: macOS Sequoia or newer.

```diff
     custom_block: |
-      depends_on :macos => :sequoia
+      on_macos do
+        depends_on macos: :sequoia
+      end
```

**Verification** (Homebrew 4.x): the current formula reproduces the warning when loaded; the patched form loads clean with no deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
