### PR TITLE
Use GitHub macOS 26 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
+    runs-on: macos-26
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
@@ -30,17 +30,9 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
 
   test:
-    name: Test on macOS ${{ matrix.macos }}
-    runs-on: ghcr.io/cirruslabs/macos-runner:${{ matrix.runner }}
+    name: Test on macOS 26
+    runs-on: macos-26
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - macos: Sequoia
-            runner: sequoia
-          - macos: Tahoe
-            runner: tahoe
     steps:
       - uses: actions/checkout@v6
       - name: Install Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
   release:
     name: Release
     if: github.event_name == 'push' && github.ref_type == 'tag'
-    runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
+    runs-on: macos-26
     environment: publish
     timeout-minutes: 60
     steps:
@@ -58,7 +58,7 @@ jobs:
   snapshot:
     name: Release (Dry Run)
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ghcr.io/cirruslabs/macos-runner:tahoe
+    runs-on: macos-26
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## What changed

- replace the Cirrus Labs macOS runner labels with GitHub-hosted `macos-26`
- collapse the Sequoia/Tahoe test matrix into one macOS 26 test job
- run release and snapshot jobs on the same GitHub-hosted image

## Why

The release workflows should use the supported GitHub-hosted macOS 26 ARM64 image instead of Cirrus Labs runner images.

## Installation

```sh
brew install openai/tools/softnet
```

## Validation

- `GOPATH=/Users/fkorotkov/.cache/codex-go GOMODCACHE=/Users/fkorotkov/.cache/codex-go/pkg/mod GOCACHE=/Users/fkorotkov/.cache/codex-go-build go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yml`
- `git diff --check`
