### PR TITLE
Normalize startup policy CIDRs

### DIFF
--- a/lib/proxy/control.rs
+++ b/lib/proxy/control.rs
@@ -117,10 +117,7 @@ fn parse_targets(targets: Vec<String>) -> std::result::Result<Vec<Target>, Error
 fn normalize_targets(targets: Vec<Target>) -> Vec<Target> {
     let mut targets = targets
         .into_iter()
-        .map(|target| match target {
-            Target::Prefix(prefix) => Target::Prefix(prefix.trunc()),
-            Target::Host => Target::Host,
-        })
+        .map(Target::normalize)
         .collect::<Vec<_>>();
 
     targets.sort_by_key(target_string);

--- a/lib/proxy/mod.rs
+++ b/lib/proxy/mod.rs
@@ -42,6 +42,15 @@ pub enum Target {
     Host,
 }
 
+impl Target {
+    fn normalize(self) -> Self {
+        match self {
+            Target::Prefix(prefix) => Target::Prefix(prefix.trunc()),
+            Target::Host => Target::Host,
+        }
+    }
+}
+
 impl FromStr for Target {
     type Err = ipnet::AddrParseError;
 
@@ -71,6 +80,8 @@ impl Proxy<'_> {
         control_fd: Option<RawFd>,
     ) -> Result<Proxy<'proxy>> {
         let vm = VM::new(vm_fd)?;
+        let allow = allow.into_iter().map(Target::normalize).collect::<Vec<_>>();
+        let block = block.into_iter().map(Target::normalize).collect::<Vec<_>>();
         let host = Host::new(
             vm_net_type,
             !allow.contains(&Target::Prefix(Ipv4Net::default())),
@@ -260,7 +271,7 @@ impl Proxy<'_> {
 mod tests {
     use crate::NetType;
     use crate::dhcp_snooper::Lease;
-    use crate::proxy::{Action, Proxy};
+    use crate::proxy::{Action, Proxy, Target};
     use ipnet::Ipv4Net;
     use mac_address::MacAddress;
     use nix::sys::socket::{AddressFamily, SockFlag, SockType, socketpair};
@@ -271,6 +282,14 @@ mod tests {
     use std::os::fd::AsRawFd;
     use std::str::FromStr;
     use std::time::Duration;
+
+    #[test]
+    fn test_target_normalization_canonicalizes_default_route() {
+        assert_eq!(
+            Target::Prefix(Ipv4Net::from_str("192.0.2.1/0").unwrap()).normalize(),
+            Target::Prefix(Ipv4Net::default())
+        );
+    }
 
     #[test]
     #[serial]


### PR DESCRIPTION
`Proxy::new` decides whether to enable bridge isolation from the startup `--allow` targets. Unlike policy updates received through the control socket, those targets were not normalized first.

`ipnet` preserves host bits when parsing a CIDR, so `192.0.2.1/0` and `0.0.0.0/0` are distinct values until truncated. The packet filter still treats both as the default route, but the exact isolation check only recognized `0.0.0.0/0`. As a result, an equivalent `/0` spelling allowed all destinations while unexpectedly leaving bridge isolation enabled.

Canonicalize startup targets before configuring the host and building the packet-filter rules. Prefix normalization now lives on `Target` and is shared with control policy updates, while the control path keeps its existing sorting and deduplication behavior.

Tests:
- `cargo test --no-run`
- `cargo clippy --all-targets -- -D warnings`
- startup target normalization regression test
- existing control target normalization test